### PR TITLE
Update cpsw/framework to version R4.5.0 which will support displaying unicode characters

### DIFF
--- a/env.slac.sh
+++ b/env.slac.sh
@@ -1,3 +1,3 @@
-. /afs/slac/g/lcls/package/cpsw/framework/R4.4.2/rhel6-x86_64/bin/env-cpsw.sh
+. /afs/slac/g/lcls/package/cpsw/framework/R4.5.0/rhel6-x86_64/bin/env-cpsw.sh
 . /afs/slac/g/lcls/package/python/3.6.1/rhel6-x86_64/use.bash
 export PYTHONPATH=${PYTHONPATH}:$(dirname -- "$(readlink -f $0)")


### PR DESCRIPTION
See slaclab/cpsw@15921f26bfc27a122c37e36554f07abf66e0de96 for the change that this will pick up. This will be included in the new `pycpsw.so` from 4.5.0.