### PR TITLE
Update the tree gui to use a conda environment

### DIFF
--- a/cpswTreeGUI.py
+++ b/cpswTreeGUI.py
@@ -15,9 +15,8 @@ import socket
 import getopt
 import re
 import os
-import sip
+from   PyQt5                              import QtCore, QtGui, QtWidgets, sip
 sip.setapi('QString', 2)
-from   PyQt5                              import QtCore, QtGui, QtWidgets
 from   PyQt5.QtGui                        import QDoubleValidator
 import yaml_cpp
 import signal

--- a/env.slac.sh
+++ b/env.slac.sh
@@ -1,3 +1,3 @@
 . /afs/slac/g/lcls/package/cpsw/framework/R4.5.0/rhel6-x86_64/bin/env-cpsw.sh
-. /afs/slac/g/lcls/package/python/3.6.1/rhel6-x86_64/use.bash
+. /afs/slac/g/lcls/package/anaconda/envs/python3.8envs/v2.5/bin/activate
 export PYTHONPATH=${PYTHONPATH}:$(dirname -- "$(readlink -f $0)")


### PR DESCRIPTION
env.slac.sh will now point to our python 3.8 conda environment.

And it now grabs the sip directly from PyQt5 (as well as just uses the PyQt5 from our conda environment saving us the trouble of having to build it separately)